### PR TITLE
Add Html 5 Placeholder and Required attribute support to editor templates

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,10 +1,19 @@
-Copyright (c) 2011, Scott Kirkland
-All rights reserved.
+Copyright (C) 2011 by Paul Tyng
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-    * Neither the name of the Scott Kirkland nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/html5Templates.Web/Models/KitchenSink.cs
+++ b/src/html5Templates.Web/Models/KitchenSink.cs
@@ -7,42 +7,68 @@ namespace html5Templates.Web.Models
     {
         /* Note: [DataType("TemplateName")] and Mvc's [UIHint("TemplateName")] are equivalent for our purposes */
 
+        [Display(Prompt = "Enter your string...")]
+        [Required]
         public string RegularString { get; set; }
 
         [DataType(DataType.EmailAddress)]
+        [Display(Prompt = "Enter your email...")]
+        [Required]
         public string Email { get; set; }
 
         [DataType(DataType.Url)]
+        [Display(Prompt = "Enter a url...")]
+        [Required]
         public string Url { get; set; }
 
         [DataType(DataType.PhoneNumber)]
+        [Display(Prompt = "Enter your phone...")]
+        [Required]
         public string Phone { get; set; }
 
         [DataType("Search")]
+        [Display(Prompt = "Enter your search...")]
         public string Search { get; set; }
 
         //[DataType(DataType.DateTime)] //Redundant
+        [Required]
         public DateTime DateTime { get; set; }
         
         [DataType("DateTime-Local")]
+        [Required]
         public DateTime DateTimeLocal { get; set; }
 
         [DataType(DataType.Date)]
+        [Required]
         public DateTime DateOnly { get; set; }
 
         [DataType(DataType.Time)]
+        [Required]
         public string TimeOnly { get; set; }
 
         [DataType("Month")]
+        [Required]
         public string Month { get; set; }
 
         [DataType("Week")]
+        [Required]
         public string Week { get; set; }
 
         [DataType("Number")] //On Opera number uses a spinbox, so this will only work with integers
+        [Required]
         public int Number { get; set; }
 
         [DataType("Color")]
         public string Color { get; set; }
+        
+        [DataType(DataType.Text)]
+        [Display(Prompt = "Enter your text...")]
+        [Required]
+        public string Text { get; set; }
+
+        [DataType(DataType.MultilineText)]
+        [Display(Prompt = "Enter your multiline text...")]
+        [Required]
+        public string MultilineText { get; set; }
     }
 }

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Color.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Color.cshtml
@@ -1,1 +1,7 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "color" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "color");
+    attributes.Add("class", "text-box single-line");
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Date.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Date.cshtml
@@ -1,1 +1,12 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "date" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "date");
+    attributes.Add("class", "text-box single-line");
+
+    if (ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/DateTime-Local.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/DateTime-Local.cshtml
@@ -1,1 +1,12 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "datetime-local" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "datetime-local");
+    attributes.Add("class", "text-box single-line");
+
+    if (ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/DateTime.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/DateTime.cshtml
@@ -1,1 +1,12 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "datetime" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "datetime");
+    attributes.Add("class", "text-box single-line");
+
+    if (ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/DateTime.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/DateTime.cshtml
@@ -2,7 +2,16 @@
     var attributes = new Dictionary<string, object>();
 
     attributes.Add("type", "datetime");
+
     attributes.Add("class", "text-box single-line");
+
+    //since this is a constraint, IsRequired and other constraints 
+    //won't necessarily apply in the browser, but in case script 
+    //turns off readonly we want the constraints passed
+    if (ViewData.ModelMetadata.IsReadOnly)
+    {
+        attributes.Add("readonly", "readonly");
+    }
 
     if (ViewData.ModelMetadata.IsRequired)
     {

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/EmailAddress.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/EmailAddress.cshtml
@@ -2,8 +2,17 @@
     var attributes = new Dictionary<string, object>();
 
     attributes.Add("type", "email");
+    
     attributes.Add("class", "text-box single-line");
     attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
+
+    //since this is a constraint, IsRequired and other constraints 
+    //won't necessarily apply in the browser, but in case script 
+    //turns off readonly we want the constraints passed
+    if (ViewData.ModelMetadata.IsReadOnly)
+    {
+        attributes.Add("readonly", "readonly");
+    }
 
     if (ViewData.ModelMetadata.IsRequired)
     {

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/EmailAddress.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/EmailAddress.cshtml
@@ -1,1 +1,13 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "email" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "email");
+    attributes.Add("class", "text-box single-line");
+    attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
+
+    if (ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Month.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Month.cshtml
@@ -1,1 +1,12 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "month" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "month");
+    attributes.Add("class", "text-box single-line");
+
+    if (ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/MultilineText.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/MultilineText.cshtml
@@ -1,10 +1,18 @@
 ﻿@{
     var attributes = new Dictionary<string, object>();
-    
+
     attributes.Add("class", "text-box multi-line");
     attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
-    
-    if(ViewData.ModelMetadata.IsRequired)
+
+    //If this is true, IsRequired and other constraints 
+    //won't necessarily apply in the browser, but in case script 
+    //turns off readonly we want the constraints passed
+    if (ViewData.ModelMetadata.IsReadOnly)
+    {
+        attributes.Add("readonly", "readonly");
+    }
+
+    if (ViewData.ModelMetadata.IsRequired)
     {
         attributes.Add("required", "required");
     }

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/MultilineText.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/MultilineText.cshtml
@@ -1,0 +1,12 @@
+﻿@{
+    var attributes = new Dictionary<string, object>();
+    
+    attributes.Add("class", "text-box multi-line");
+    attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
+    
+    if(ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextArea(string.Empty, ViewData.TemplateInfo.FormattedModelValue.ToString(), 0, 0, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Number.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Number.cshtml
@@ -1,1 +1,12 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "number" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "number");
+    attributes.Add("class", "text-box single-line");
+
+    if (ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Password.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Password.cshtml
@@ -1,0 +1,12 @@
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("class", "text-box single-line password");
+    attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
+    
+    if(ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.Password(string.Empty, ViewContext.ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/PhoneNumber.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/PhoneNumber.cshtml
@@ -9,5 +9,10 @@
     {
         attributes.Add("required", "required");
     }
+
+    if (ViewData.ModelMetadata.IsReadOnly)
+    {
+        attributes.Add("readonly", "readonly");
+    }
 }
 @Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/PhoneNumber.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/PhoneNumber.cshtml
@@ -1,1 +1,13 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "tel" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "tel");
+    attributes.Add("class", "text-box single-line");
+    attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
+
+    if (ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Search.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Search.cshtml
@@ -1,13 +1,1 @@
-﻿@{
-    var attributes = new Dictionary<string, object>();
-
-    attributes.Add("type", "search");
-    attributes.Add("class", "text-box single-line");
-    attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
-
-    if (ViewData.ModelMetadata.IsRequired)
-    {
-        attributes.Add("required", "required");
-    }
-}
-@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)
+﻿@Html.EditorForModel("String", new { type = "search" })

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Search.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Search.cshtml
@@ -1,1 +1,13 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "search" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "search");
+    attributes.Add("class", "text-box single-line");
+    attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
+
+    if (ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/String.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/String.cshtml
@@ -1,10 +1,20 @@
-﻿@{
+﻿@* 'Text' and 'Search' are dependent upon this template (text and search both follow the same rules in HTML 5) *@
+
+@{
     var attributes = new Dictionary<string, object>();
-    
+
     attributes.Add("class", "text-box single-line");
     attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
-    
-    if(ViewData.ModelMetadata.IsRequired)
+
+    //If this is true, IsRequired and other constraints 
+    //won't necessarily apply in the browser, but in case script 
+    //turns off readonly we want the constraints passed
+    if (ViewData.ModelMetadata.IsReadOnly)
+    {
+        attributes.Add("readonly", "readonly");
+    }
+
+    if (ViewData.ModelMetadata.IsRequired)
     {
         attributes.Add("required", "required");
     }

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/String.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/String.cshtml
@@ -1,13 +1,12 @@
 ﻿@{
     var attributes = new Dictionary<string, object>();
-
-    attributes.Add("type", "url");
+    
     attributes.Add("class", "text-box single-line");
     attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
-
-    if (ViewData.ModelMetadata.IsRequired)
+    
+    if(ViewData.ModelMetadata.IsRequired)
     {
         attributes.Add("required", "required");
     }
 }
-@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)
+@Html.TextBox(string.Empty, ViewContext.ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Text.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Text.cshtml
@@ -1,12 +1,12 @@
 ﻿@{
     var attributes = new Dictionary<string, object>();
 
-    attributes.Add("type", "time");
     attributes.Add("class", "text-box single-line");
+    attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
 
     if (ViewData.ModelMetadata.IsRequired)
     {
         attributes.Add("required", "required");
     }
 }
-@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)
+@Html.TextBox(string.Empty, ViewContext.ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Text.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Text.cshtml
@@ -1,12 +1,1 @@
-﻿@{
-    var attributes = new Dictionary<string, object>();
-
-    attributes.Add("class", "text-box single-line");
-    attributes.Add("placeholder", ViewData.ModelMetadata.Watermark);
-
-    if (ViewData.ModelMetadata.IsRequired)
-    {
-        attributes.Add("required", "required");
-    }
-}
-@Html.TextBox(string.Empty, ViewContext.ViewData.TemplateInfo.FormattedModelValue, attributes)
+﻿@Html.EditorForModel("String", new { type = "search" })

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Url.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Url.cshtml
@@ -9,5 +9,10 @@
     {
         attributes.Add("required", "required");
     }
+
+    if (ViewData.ModelMetadata.IsReadOnly)
+    {
+        attributes.Add("readonly", "readonly");
+    }
 }
 @Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/Views/Shared/EditorTemplates/Week.cshtml
+++ b/src/html5Templates.Web/Views/Shared/EditorTemplates/Week.cshtml
@@ -1,1 +1,12 @@
-﻿@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, new { @class = "text-box single-line", type = "week" })
+﻿@{
+    var attributes = new Dictionary<string, object>();
+
+    attributes.Add("type", "week");
+    attributes.Add("class", "text-box single-line");
+
+    if (ViewData.ModelMetadata.IsRequired)
+    {
+        attributes.Add("required", "required");
+    }
+}
+@Html.TextBox("", ViewData.TemplateInfo.FormattedModelValue, attributes)

--- a/src/html5Templates.Web/html5Templates.Web.csproj
+++ b/src/html5Templates.Web/html5Templates.Web.csproj
@@ -13,7 +13,8 @@
     <RootNamespace>html5Templates.Web</RootNamespace>
     <AssemblyName>html5Templates.Web</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <MvcBuildViews>false</MvcBuildViews>
+    <MvcBuildViews>true</MvcBuildViews>
+    <UseIISExpress>false</UseIISExpress>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -138,7 +139,9 @@
     <Content Include="Views\Shared\Error.cshtml" />
     <Content Include="Views\Shared\_Layout.cshtml" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="Views\Shared\EditorTemplates\String.cshtml" />
+  </ItemGroup>
   <ItemGroup>
     <Content Include="Views\Home\Index.cshtml" />
   </ItemGroup>
@@ -186,6 +189,15 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\Demo\ViewPage1.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Shared\EditorTemplates\Text.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Shared\EditorTemplates\MultilineText.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Shared\EditorTemplates\Password.cshtml" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />


### PR DESCRIPTION
Now the inputs will render with these attributes when they are specified in metadata:

```
<input class="text-box single-line" id="RegularString" name="RegularString" placeholder="Enter your string..." required="required" type="text" value="">
```

Note the additional attributes.  `placeholder` pulls from the `ModelMetadata.Watermark`, `required` pulls from `ModelMetadata.IsRequired`
